### PR TITLE
Replace https with http.

### DIFF
--- a/plugin.video.sdarot.tv/resources/lib/sdarotcommons.py
+++ b/plugin.video.sdarot.tv/resources/lib/sdarotcommons.py
@@ -20,7 +20,7 @@ HEADERS = {
 FANART = plugin.addon.getAddonInfo('fanart')
 ICON = plugin.addon.getAddonInfo('icon')
 API = base64.decodestring('aHR0cHM6Ly9hcGkuc2Rhcm90LnR2')
-POSTER_PREFIX = base64.decodestring('aHR0cHM6Ly93d3cuZG9tYWluNGtvZGkubGlmZS9zZXJpZXMv')
+POSTER_PREFIX = base64.decodestring('aHR0cDovL3d3dy5kb21haW40a29kaS5saWZlL3Nlcmllcy8=')
 CACHE_FILE = os.path.join(xbmc.translatePath(plugin.addon.getAddonInfo('profile')).decode('utf-8'), 'cache.json')
 
 


### PR DESCRIPTION
Getting poster art via HTTPS from a domain makes poster art unavailable, because python CCURL errors out on certificate validation (domain does not match what is written in the certificate)

Replacing with simple HTTP (alternatively, you can fix the certificate or fix the URL in the encoded string, but this seems to be less work all around)